### PR TITLE
Feature svgmap macro improvements

### DIFF
--- a/lib/stepmod/utils/converters/express_g.rb
+++ b/lib/stepmod/utils/converters/express_g.rb
@@ -24,18 +24,18 @@ module Stepmod
             ====
             image::#{svg_path}.svg[]
 
-            #{image_document.xpath('//img.area').map {|n| schema_reference(n['href']) }.join("\n")}
+            #{image_document.xpath('//img.area').map.with_index(1) {|n, i| schema_reference(n['href'], i) }.join("\n")}
             ====
           SVGMAP
         end
 
-        def schema_reference(xml_path)
+        def schema_reference(xml_path, index)
           if xml_path =~ /#/
             _,express_path_part = xml_path.split('#')
-            "* <<express:#{express_path_part},#{express_path_part.split('.').first.strip}>>; #{xml_path}"
+            "* <<express:#{express_path_part.strip}>>; #{index}"
           else
             schema_name = File.basename(xml_path, '.*')
-            "* <<express:#{schema_name},#{schema_name}>>; #{xml_path}"
+            "* <<express:#{schema_name.strip}>>; #{index}"
           end
         end
       end

--- a/spec/stepmod/converters/extpress_g_spec.rb
+++ b/spec/stepmod/converters/extpress_g_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Stepmod::Utils::Converters::ExpressG do
       ====
       image::basic_attribute_schemaexpg1.svg[]
 
-      * <<express:support_resource_schema,support_resource_schema>>; ../../resources/support_resource_schema/support_resource_schema.xml
-      * <<express:basic_attribute_schema,basic_attribute_schema>>; ../../resources/basic_attribute_schema/basic_attribute_schema.xml
+      * <<express:support_resource_schema>>; 1
+      * <<express:basic_attribute_schema>>; 2
       ====
 
 
@@ -30,8 +30,8 @@ RSpec.describe Stepmod::Utils::Converters::ExpressG do
       ====
       image::basic_attribute_schemaexpg2.svg[]
 
-      * <<express:custom.name,custom>>; ../../resources/custom/custom.xml#custom.name
-      * <<express:custom2.name2,custom2>>; ../../resources/custom2/custom2.xml#custom2.name2
+      * <<express:custom.name>>; 1
+      * <<express:custom2.name2>>; 2
       ====
 
 
@@ -39,21 +39,21 @@ RSpec.describe Stepmod::Utils::Converters::ExpressG do
       ====
       image::action_and_model_relationships_schemaexpg1.svg[]
 
-      * <<express:product_and_model_relationships_schema,product_and_model_relationships_schema>>; ../../resources/product_and_model_relationships_schema/product_and_model_relationships_schema.xml#product_and_model_relationships_schema
-      * <<express:action_and_model_relationships_schema,action_and_model_relationships_schema>>; ../../resources/action_and_model_relationships_schema/action_and_model_relationships_schema.xml#action_and_model_relationships_schema
-      * <<express:state_and_model_relationships_schema,state_and_model_relationships_schema>>; ../../resources/state_and_model_relationships_schema/state_and_model_relationships_schema.xml#state_and_model_relationships_schema
-      * <<express:property_distribution_and_model_relationships_schema,property_distribution_and_model_relationships_schema>>; ../../resources/property_distribution_and_model_relationships_schema/property_distribution_and_model_relationships_schema.xml#property_distribution_and_model_relationships_schema
-      * <<express:product_definition_schema,product_definition_schema>>; ../../resources/product_definition_schema/product_definition_schema.xml#product_definition_schema
-      * <<express:structural_response_representation_schema,structural_response_representation_schema>>; ../../resources/structural_response_representation_schema/structural_response_representation_schema.xml#structural_response_representation_schema
-      * <<express:product_analysis_schema,product_analysis_schema>>; ../../resources/product_analysis_schema/product_analysis_schema.xml#product_analysis_schema
-      * <<express:analysis_schema,analysis_schema>>; ../../resources/analysis_schema/analysis_schema.xml#analysis_schema
-      * <<express:support_resource_schema,support_resource_schema>>; ../../resources/support_resource_schema/support_resource_schema.xml#support_resource_schema
-      * <<express:action_schema,action_schema>>; ../../resources/action_schema/action_schema.xml#action_schema
-      * <<express:finite_element_analysis_control_and_result_schema,finite_element_analysis_control_and_result_schema>>; ../../resources/finite_element_analysis_control_and_result_schema/finite_element_analysis_control_and_result_schema.xml#finite_element_analysis_control_and_result_schema
-      * <<express:state_type_schema,state_type_schema>>; ../../resources/state_type_schema/state_type_schema.xml#state_type_schema
-      * <<express:product_property_definition_schema,product_property_definition_schema>>; ../../resources/product_property_definition_schema/product_property_definition_schema.xml#product_property_definition_schema
-      * <<express:fea_definition_relationships_schema,fea_definition_relationships_schema>>; ../../resources/fea_definition_relationships_schema/fea_definition_relationships_schema.xml#fea_definition_relationships_schema
-      * <<express:topology_schema,topology_schema>>; ../../resources/topology_schema/topology_schema.xml#topology_schema
+      * <<express:product_and_model_relationships_schema>>; 1
+      * <<express:action_and_model_relationships_schema>>; 2
+      * <<express:state_and_model_relationships_schema>>; 3
+      * <<express:property_distribution_and_model_relationships_schema>>; 4
+      * <<express:product_definition_schema>>; 5
+      * <<express:structural_response_representation_schema>>; 6
+      * <<express:product_analysis_schema>>; 7
+      * <<express:analysis_schema>>; 8
+      * <<express:support_resource_schema>>; 9
+      * <<express:action_schema>>; 10
+      * <<express:finite_element_analysis_control_and_result_schema>>; 11
+      * <<express:state_type_schema>>; 12
+      * <<express:product_property_definition_schema>>; 13
+      * <<express:fea_definition_relationships_schema>>; 14
+      * <<express:topology_schema>>; 15
       ====
 
     ADOC

--- a/spec/stepmod/converters/schema_diag_spec.rb
+++ b/spec/stepmod/converters/schema_diag_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Stepmod::Utils::Converters::SchemaDiag do
       ====
       image::basic_attribute_schemaexpg1.svg[]
 
-      * <<express:support_resource_schema,support_resource_schema>>; ../../resources/support_resource_schema/support_resource_schema.xml
-      * <<express:basic_attribute_schema,basic_attribute_schema>>; ../../resources/basic_attribute_schema/basic_attribute_schema.xml
+      * <<express:support_resource_schema>>; 1
+      * <<express:basic_attribute_schema>>; 2
       ====
     XML
   end

--- a/spec/stepmod/smrl_resource_converter_spec.rb
+++ b/spec/stepmod/smrl_resource_converter_spec.rb
@@ -37,16 +37,16 @@ RSpec.describe Stepmod::Utils::SmrlResourceConverter do
       ====
       image::basic_attribute_schemaexpg1.svg[]
 
-      * <<express:support_resource_schema,support_resource_schema>>; ../../resources/support_resource_schema/support_resource_schema.xml
-      * <<express:basic_attribute_schema,basic_attribute_schema>>; ../../resources/basic_attribute_schema/basic_attribute_schema.xml
+      * <<express:support_resource_schema>>; 1
+      * <<express:basic_attribute_schema>>; 2
       ====
 
       [.svgmap]
       ====
       image::basic_attribute_schemaexpg2.svg[]
 
-      * <<express:custom.name,custom>>; ../../resources/custom/custom.xml#custom.name
-      * <<express:custom2.name2,custom2>>; ../../resources/custom2/custom2.xml#custom2.name2
+      * <<express:custom.name>>; 1
+      * <<express:custom2.name2>>; 2
       ====
       *)
     ADOC


### PR DESCRIPTION
metanorma/iso-10303-stepmod#12 improvements fro svgmap conversion:

Change:

```ruby
[.svgmap]
====
image::action_schemaexpg1.svg[]

* <<express:basic_attribute_schema,basic_attribute_schema>>; ../../resources/basic_attribute_schema/basic_attribute_schema.xml
* <<express:action_schema,action_schema>>; ../../resources/action_schema/action_schema.xml
* <<express:support_resource_schema,support_resource_schema>>; ../../resources/support_resource_schema/support_resource_schema.xml
====

```

Into:

```ruby
[.svgmap]
====
image::action_schemaexpg1.svg[]

* <<express:basic_attribute_schema>>; 1
* <<express:action_schema>>; 2
* <<express:support_resource_schema>>; 3
====
```