### PR TITLE
(Feature) In annotated EXPRESS schemas, general, fund_cons and express-g blocks should all be separately tagged

### DIFF
--- a/lib/stepmod/utils/converters/express_g.rb
+++ b/lib/stepmod/utils/converters/express_g.rb
@@ -8,21 +8,23 @@ module Stepmod
           node.children.map do |child|
             next unless child.name == 'imgfile'
 
-            parse_to_svg_reference(child['file'])
+            parse_to_svg_reference(child['file'], state)
           end.join("\n")
         end
 
         private
 
-        def parse_to_svg_reference(file)
+        def parse_to_svg_reference(file, state)
           return '' unless File.file?(file)
 
           image_document = Nokogiri::XML(File.read(file))
           svg_path = File.basename(image_document.xpath('//img').first['src'], '.*')
           <<~SVGMAP
+            *)
+
+            (*"#{state.fetch(:schema_name, 'action_schema')}.__expressg"
             [.svgmap]
             ====
-            [[#{svg_path}]]
             image::#{svg_path}.svg[]
 
             #{image_document.xpath('//img.area').map.with_index(1) {|n, i| schema_reference(n['href'], i) }.join("\n")}

--- a/lib/stepmod/utils/converters/ext_description.rb
+++ b/lib/stepmod/utils/converters/ext_description.rb
@@ -3,6 +3,7 @@ module Stepmod
     module Converters
       class ExtDescription < ReverseAdoc::Converters::Base
         def convert(node, state = {})
+          state = state.merge(schema_name: node['linkend'])
           <<~TEMPLATE
             (*"#{node['linkend']}"
             #{treat_children(node, state).strip}

--- a/lib/stepmod/utils/converters/fund_cons.rb
+++ b/lib/stepmod/utils/converters/fund_cons.rb
@@ -5,7 +5,13 @@ module Stepmod
     module Converters
       class FundCons < ReverseAdoc::Converters::Base
         def convert(node, state = {})
-          "\n\n== Fundamental concepts and assumptions\n\n#{treat_children(node, state).strip}\n\n"
+          <<~TEXT
+            *)
+
+            (*"#{state.fetch(:schema_name, 'action_schema')}.__fund_cons"
+
+            #{treat_children(node, state).strip}
+          TEXT
         end
       end
 

--- a/lib/stepmod/utils/converters/introduction.rb
+++ b/lib/stepmod/utils/converters/introduction.rb
@@ -5,7 +5,7 @@ module Stepmod
     module Converters
       class Introduction < ReverseAdoc::Converters::Base
         def convert(node, state = {})
-          "\n\n== General\n\n#{treat_children(node, state).strip}\n\n"
+          treat_children(node, state)
         end
       end
 

--- a/lib/stepmod/utils/converters/schema.rb
+++ b/lib/stepmod/utils/converters/schema.rb
@@ -5,6 +5,7 @@ module Stepmod
     module Converters
       class Schema < ReverseAdoc::Converters::Base
         def convert(node, state = {})
+          state = state.merge(schema_name: node['name'])
           <<~TEMPLATE
             (*"#{node['name']}"
             #{treat_children(node, state).strip}

--- a/spec/stepmod/converters/extpress_g_spec.rb
+++ b/spec/stepmod/converters/extpress_g_spec.rb
@@ -16,9 +16,11 @@ RSpec.describe Stepmod::Utils::Converters::ExpressG do
   let(:adoc_output) do
     <<~ADOC
 
+      *)
+
+      (*"action_schema.__expressg"
       [.svgmap]
       ====
-      [[basic_attribute_schemaexpg1]]
       image::basic_attribute_schemaexpg1.svg[]
 
       * <<express:support_resource_schema>>; 1
@@ -26,9 +28,11 @@ RSpec.describe Stepmod::Utils::Converters::ExpressG do
       ====
 
 
+      *)
+
+      (*"action_schema.__expressg"
       [.svgmap]
       ====
-      [[basic_attribute_schemaexpg2]]
       image::basic_attribute_schemaexpg2.svg[]
 
       * <<express:custom.name>>; 1
@@ -36,9 +40,11 @@ RSpec.describe Stepmod::Utils::Converters::ExpressG do
       ====
 
 
+      *)
+
+      (*"action_schema.__expressg"
       [.svgmap]
       ====
-      [[action_and_model_relationships_schemaexpg1]]
       image::action_and_model_relationships_schemaexpg1.svg[]
 
       * <<express:product_and_model_relationships_schema>>; 1

--- a/spec/stepmod/converters/schema_diag_spec.rb
+++ b/spec/stepmod/converters/schema_diag_spec.rb
@@ -16,9 +16,11 @@ RSpec.describe Stepmod::Utils::Converters::SchemaDiag do
   end
   let(:output) do
     <<~XML
+      *)
+
+      (*"action_schema.__expressg"
       [.svgmap]
       ====
-      [[basic_attribute_schemaexpg1]]
       image::basic_attribute_schemaexpg1.svg[]
 
       * <<express:support_resource_schema>>; 1

--- a/spec/stepmod/smrl_resource_converter_spec.rb
+++ b/spec/stepmod/smrl_resource_converter_spec.rb
@@ -25,26 +25,28 @@ RSpec.describe Stepmod::Utils::SmrlResourceConverter do
   let(:output) do
     <<~ADOC
       (*"contract_schema"
-      == General
+      The subject of the *contract_schema* is the description of contract agreements. *)
 
-      The subject of the *contract_schema* is the description of contract agreements.
-
-      == Fundamental concepts and assumptions
+      (*"contract_schema.__fund_cons"
 
       Contract information may be attached to any aspect of a product data.
 
+      *)
+
+      (*"contract_schema.__expressg"
       [.svgmap]
       ====
-      [[basic_attribute_schemaexpg1]]
       image::basic_attribute_schemaexpg1.svg[]
 
       * <<express:support_resource_schema>>; 1
       * <<express:basic_attribute_schema>>; 2
       ====
 
+      *)
+
+      (*"contract_schema.__expressg"
       [.svgmap]
       ====
-      [[basic_attribute_schemaexpg2]]
       image::basic_attribute_schemaexpg2.svg[]
 
       * <<express:custom.name>>; 1


### PR DESCRIPTION
https://github.com/metanorma/stepmod-utils/issues/69, new conversion result is in https://github.com/metanorma/iso-10303-stepmod/pull/28