### PR TITLE
(Feature) Content in <term> contained within parentheses should be labeled as an acronym

### DIFF
--- a/lib/stepmod/utils/converters/term.rb
+++ b/lib/stepmod/utils/converters/term.rb
@@ -13,13 +13,22 @@ module Stepmod
           unless first_child &&
               node.text.split(";").length == 2 &&
               defined?(Stepmod::Utils::Converters::Synonym)
-            return "=== #{treat_children(node, state).strip}"
+            return "=== #{treat_acronym(treat_children(node, state).strip)}"
           end
 
           term_def, alt = node.text.split(";")
           alt_xml = Nokogiri::XML::Text.new(alt, Nokogiri::XML::Document.new)
           converted_alt = Stepmod::Utils::Converters::Synonym.new.convert(alt_xml)
-          "=== #{term_def}\n\n#{converted_alt}"
+          "=== #{treat_acronym(term_def)}\n\n#{converted_alt}"
+        end
+
+        private
+
+        def treat_acronym(term_def)
+          return term_def if term_def !~ /.+\(.+?\)$/
+
+          _, term_text, term_acronym = term_def.match(/(.+?)(\(.+\))$/).to_a
+          "#{term_text}\nalt:[#{term_acronym.gsub(/\(|\)/, '')}]"
         end
       end
 

--- a/spec/stepmod/converters/definition_spec.rb
+++ b/spec/stepmod/converters/definition_spec.rb
@@ -134,4 +134,53 @@ RSpec.describe Stepmod::Utils::Converters::Definition do
       expect(convert.strip).to eq(output)
     end
   end
+
+  context 'when term in definition xml has acronym' do
+    let(:input_xml) do
+      <<~TEXT
+        <definition>
+          <term>directed acyclic graph (DAG)</term>
+          <def>
+            collection of nodes and links such that no node is an ancestor (or descendant) of itself
+          </def>
+        </definition>
+      TEXT
+    end
+    let(:output) do
+      <<~XML
+      === directed acyclic graph
+      alt:[DAG]
+
+      collection of nodes and links such that no node is an ancestor (or descendant) of itself
+      XML
+    end
+
+    it "converts complex children block by rules" do
+      expect(convert).to eq(output.strip)
+    end
+  end
+
+  context 'when term in definition xml has braces' do
+    let(:input_xml) do
+      <<~TEXT
+        <definition>
+          <term>bill-of-material (BOM) data structure</term>
+          <def>
+            collection of nodes and links such that no node is an ancestor (or descendant) of itself
+          </def>
+        </definition>
+      TEXT
+    end
+    let(:output) do
+      <<~XML
+      === bill-of-material (BOM) data structure
+
+      collection of nodes and links such that no node is an ancestor (or descendant) of itself
+      XML
+    end
+
+    it "converts complex children block by rules" do
+      expect(convert).to eq(output.strip)
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/metanorma/stepmod-utils/issues/10 Content in <term> contained within parentheses should be labeled as an acronym