### PR TITLE
fix: Broken remark tags for `__note` and `__example`, fixes #127

### DIFF
--- a/lib/stepmod/utils/converters/express_example.rb
+++ b/lib/stepmod/utils/converters/express_example.rb
@@ -6,7 +6,7 @@ module Stepmod
       class ExpressExample < ReverseAdoc::Converters::Base
         def convert(node, state = {})
           <<~TEMPLATE
-            (*"#{state['schema_and_entity']}.__example"
+            (*"#{state[:schema_and_entity]}.__example"
             #{treat_children(node, state).strip}
             *)
           TEMPLATE

--- a/lib/stepmod/utils/converters/express_note.rb
+++ b/lib/stepmod/utils/converters/express_note.rb
@@ -6,7 +6,7 @@ module Stepmod
       class ExpressNote < ReverseAdoc::Converters::Base
         def convert(node, state = {})
           <<~TEMPLATE
-            (*"#{state['schema_and_entity']}.__note"
+            (*"#{state[:schema_and_entity]}.__note"
             #{treat_children(node, state).strip}
             *)
           TEMPLATE


### PR DESCRIPTION
### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
