### PR TITLE
feat: skip redundant notes

### DIFF
--- a/exe/stepmod-extract-concepts
+++ b/exe/stepmod-extract-concepts
@@ -78,7 +78,7 @@ end
 
 default_index_path = File.join(stepmod_dir, "repository_index.xml")
 index_path = options[:index_path] || default_index_path
-if File.exists?(index_path)
+if File.exist?(index_path)
   log "Repository index path: `#{index_path}`"
 else
   raise StandardError.new(

--- a/exe/stepmod-find-express-files
+++ b/exe/stepmod-find-express-files
@@ -20,5 +20,5 @@ index.xpath("business_object_models/business_object_model").each do |item|
   files << "#{stepmod_dir}/data/business_object_models/#{item['name']}/DomainModel.exp"
 end
 
-existing_files = files.filter { |file| File.exists?(file) }
+existing_files = files.filter { |file| File.exist?(file) }
 puts existing_files

--- a/lib/stepmod/utils/stepmod_file_annotator.rb
+++ b/lib/stepmod/utils/stepmod_file_annotator.rb
@@ -39,7 +39,7 @@ module Stepmod
         converted_description = ""
         base_linked = ""
 
-        if File.exists?(descriptions_file)
+        if File.exist?(descriptions_file)
           descriptions = Nokogiri::XML(File.read(descriptions_file)).root
           added_resource_descriptions = {}
 
@@ -81,7 +81,7 @@ module Stepmod
                      resource_docs_file_path(stepmod_dir, bib_file_name)
                    end
 
-        output_express << if bib_file && File.exists?(bib_file)
+        output_express << if bib_file && File.exist?(bib_file)
                             prepend_bibdata(
                               converted_description || "",
                               # bib_file will not be present for resouces

--- a/lib/stepmod/utils/terms_extractor.rb
+++ b/lib/stepmod/utils/terms_extractor.rb
@@ -87,8 +87,8 @@ module Stepmod
           arm_path = Pathname.new("#{stepmod_dir}/modules/#{x['name']}/arm_annotated.exp")
           mim_path = Pathname.new("#{stepmod_dir}/modules/#{x['name']}/mim_annotated.exp")
 
-          files << arm_path if File.exists? arm_path
-          files << mim_path if File.exists? mim_path
+          files << arm_path if File.exist? arm_path
+          files << mim_path if File.exist? mim_path
         end
 
         # Should ignore these because the `<resource_docs>` elements do not provide any EXPRESS schemas
@@ -105,7 +105,7 @@ module Stepmod
           next if x['status'] == WITHDRAWN_STATUS
 
           path = Pathname.new("#{stepmod_dir}/resources/#{x['name']}/#{x['name']}_annotated.exp")
-          files << path if File.exists? path
+          files << path if File.exist? path
         end
 
         # Should ignore these because we are skiping Clause 3 terms

--- a/lib/stepmod/utils/terms_extractor.rb
+++ b/lib/stepmod/utils/terms_extractor.rb
@@ -319,7 +319,7 @@ module Stepmod
         old_definition = trim_definition(entity.remarks.first)
         definition = generate_entity_definition(entity, domain)
 
-        notes = [old_definition].reject { |note| redundant_note?(note) }.compact
+        notes = [old_definition].reject { |note| redundant_note?(note) }
 
         Stepmod::Utils::Concept.new(
           designations: [
@@ -517,7 +517,7 @@ module Stepmod
       end
 
       def redundant_note?(note)
-        note.match?(REDUNDENT_NOTE_REGEX) && !note.include?("\n")
+        note && note.match?(REDUNDENT_NOTE_REGEX) && !note.include?("\n")
       end
     end
   end

--- a/lib/stepmod/utils/terms_extractor.rb
+++ b/lib/stepmod/utils/terms_extractor.rb
@@ -16,6 +16,7 @@ module Stepmod
       # TODO: we may want a command line option to override this in the future
       ACCEPTED_STAGES = %w(IS DIS FDIS TS).freeze
       WITHDRAWN_STATUS = "withdrawn".freeze
+      REDUNDENT_NOTE_REGEX = /^An? .*? is a type of \{\{[^}]*\}\}\s*?\.?$/.freeze
 
       attr_reader :stepmod_path,
                   :stepmod_dir,
@@ -318,6 +319,8 @@ module Stepmod
         old_definition = trim_definition(entity.remarks.first)
         definition = generate_entity_definition(entity, domain)
 
+        notes = [old_definition].reject { |note| redundant_note?(note) }.compact
+
         Stepmod::Utils::Concept.new(
           designations: [
             {
@@ -336,7 +339,7 @@ module Stepmod
               "link" => "https://www.iso.org/standard/32858.html",
             },
           ],
-          notes: [old_definition].compact,
+          notes: notes,
           language_code: "en",
           part: bibdata.part,
           schema: schema,
@@ -511,6 +514,10 @@ module Stepmod
             #{remark_item_symbol}
           REMARK
         end.join
+      end
+
+      def redundant_note?(note)
+        note.match?(REDUNDENT_NOTE_REGEX) && !note.include?("\n")
       end
     end
   end

--- a/spec/fixtures/stepmod_terms_mock_directory/data/modules/activity/arm_annotated.exp
+++ b/spec/fixtures/stepmod_terms_mock_directory/data/modules/activity/arm_annotated.exp
@@ -37,6 +37,16 @@ ENTITY Applied_activity_assignment;
   role : STRING;
 END_ENTITY;
 
+ENTITY Activity_with_a_redundant_note;
+  assigned_activity : Activity;
+  role : STRING;
+END_ENTITY;
+
+ENTITY Activity_with_an_redundant_note;
+  assigned_activity : Activity;
+  role : STRING;
+END_ENTITY;
+
 END_SCHEMA;  -- Activity_arm
 
 
@@ -129,6 +139,14 @@ The *relating_activity* usually identifies the activity the definition of the *r
 *)
 (*"Activity_arm.Activity_relationship.relating_activity.__note"
 The meaning of this attribute is defined by the *name* attribute.
+*)
+
+(*"Activity_arm.Activity_with_a_redundant_note"
+An **Activity_with_redundant_note** is a type of <<express:Activity_arm.Activity,Activity>>.
+*)
+
+(*"Activity_arm.Activity_with_an_redundant_note"
+An **Activity_with_redundant_note** is a type of <<express:Activity_arm.Activity,Activity>> .
 *)
 
 (*"Activity_arm.Activity_status"

--- a/spec/fixtures/stepmod_terms_mock_directory/data/modules/activity/arm_annotated.exp
+++ b/spec/fixtures/stepmod_terms_mock_directory/data/modules/activity/arm_annotated.exp
@@ -142,7 +142,7 @@ The meaning of this attribute is defined by the *name* attribute.
 *)
 
 (*"Activity_arm.Activity_with_a_redundant_note"
-An **Activity_with_redundant_note** is a type of <<express:Activity_arm.Activity,Activity>>.
+A **Activity_with_redundant_note** is a type of <<express:Activity_arm.Activity,Activity>>.
 *)
 
 (*"Activity_arm.Activity_with_an_redundant_note"

--- a/stepmod-utils.gemspec
+++ b/stepmod-utils.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "concurrent-ruby"
   spec.add_runtime_dependency "expressir"
-  spec.add_runtime_dependency "glossarist-new", "~> 1.0.1"
+  spec.add_runtime_dependency "glossarist", "~> 1.0.5"
   spec.add_runtime_dependency "indefinite_article"
   spec.add_runtime_dependency "ptools"
   spec.add_runtime_dependency "pubid-iso"


### PR DESCRIPTION
Added check to skip redundant notes when generating yaml concepts.

resolves #155 