### PR TITLE
using bb() and ii() for bold and italics in equation

### DIFF
--- a/lib/stepmod/utils/converters/em_express_description.rb
+++ b/lib/stepmod/utils/converters/em_express_description.rb
@@ -6,7 +6,9 @@ module Stepmod
       class Em < ReverseAdoc::Converters::Base
         def convert(node, state = {})
           content = treat_children(node, state.merge(already_italic: true))
-          if content.strip.empty? || state[:already_italic]
+          if state[:equation]
+            "ii(#{content.strip})"
+          elsif content.strip.empty? || state[:already_italic]
             content
           else
             "#{content[/^\s*/]}_#{content.strip}_#{content[/\s*$/]}"

--- a/lib/stepmod/utils/converters/eqn.rb
+++ b/lib/stepmod/utils/converters/eqn.rb
@@ -46,12 +46,13 @@ module Stepmod
           term = first_strong_node.text.strip
           first_strong_node.remove
           "\n\n#{term}:: #{remove_trash_symbols(treat_children(cloned_node,
-                                                               state))}\n"
+                                                               state.merge(equation: true)))}\n"
         end
 
         def stem_converted(cloned_node, state)
-          remove_tags_not_in_context(cloned_node)
-          internal_content = treat_children(cloned_node, state)
+          # We are now adding bb() or ii() for bold and italic respectively
+          # remove_tags_not_in_context(cloned_node)
+          internal_content = treat_children(cloned_node, state.merge(equation: true))
           content = Stepmod::Utils::HtmlToAsciimath.new.call(internal_content)
           res = <<~TEMPLATE
 

--- a/lib/stepmod/utils/converters/sub.rb
+++ b/lib/stepmod/utils/converters/sub.rb
@@ -6,7 +6,7 @@ module Stepmod
       class Sub < ReverseAdoc::Converters::Base
         def convert(node, state = {})
           content = treat_children(node, state)
-          return stem_notation(content) if node.parent.name == "eqn"
+          return stem_notation(content) if state[:equation]
 
           "#{content[/^\s*/]}~#{content.strip}~#{content[/\s*$/]}"
         end

--- a/lib/stepmod/utils/converters/sup.rb
+++ b/lib/stepmod/utils/converters/sup.rb
@@ -6,7 +6,7 @@ module Stepmod
       class Sup < ReverseAdoc::Converters::Base
         def convert(node, state = {})
           content = treat_children(node, state)
-          return stem_notation(content) if node.parent.name == "eqn"
+          return stem_notation(content) if state[:equation]
 
           "#{content[/^\s*/]}^#{content.strip}^#{content[/\s*$/]}"
         end

--- a/spec/stepmod/converters/eqn_spec.rb
+++ b/spec/stepmod/converters/eqn_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
       <eqn id="eqnGM1">
         <i>
           &#x3C7;
-          <b><i>My node</i></b>
+          <b>My node</b>
           <sub>ms</sub>
           <i>Italic text</i>
           =
@@ -33,7 +33,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
 
       [stem]
       ++++
-      χ My node_{ms}Italic text = V - E + 2F - L_{l} - 2(S - G^{s})  = 0
+      ii(χ bb(My node)_{ms}ii(Italic text) = bb(ii(V - E + 2F - L))_{l}bb(- 2(S - G)^{s})) = 0
       ++++
 
     XML
@@ -41,6 +41,34 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
 
   it "converts complex children block by rules" do
     expect(convert).to eq(output)
+  end
+
+  context "with bold and italics" do
+    let(:input_xml) do
+      <<~EQUATION
+        <eqn>
+          <b> &#955;</b><i>(u)</i> =
+          <b>C</b> +
+          R(cos(<i>u</i>)<b>x</b> +
+          sin(<i>u</i>)<b>y</b>)
+        </eqn>
+      EQUATION
+    end
+
+    let(:expected_output) do
+      <<~OUTPUT
+
+        [stem]
+        ++++
+        bb(λ)ii((u)) = bb(C) + R(cos(ii(u))bb(x) + sin(ii(u))bb(y))
+        ++++
+
+      OUTPUT
+    end
+
+    it "should add bb() and ii() for bold and italics respectively" do
+      expect(convert).to eq(expected_output)
+    end
   end
 
   context "when special symbols are used" do
@@ -55,7 +83,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
 
         [stem]
         ++++
-        χ_{ms} = V - E + 2F - L_{l}  - 2(S - G ^{s})  = 0
+        ii(χ_{ms} = bb(V - E + 2F - L)_{l} bb(- 2(S - G) ^{s})) = 0
         ++++
 
       XML
@@ -88,7 +116,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
   context "when underscore variable is used" do
     let(:input_xml) do
       <<~XML
-        <eqn> <i> K1 </i>= <b>upper_index_on_u_control_points</b> </eqn>
+        <eqn> <i> K1 </i> = <b>upper_index_on_u_control_points</b> </eqn>
       XML
     end
     let(:output) do
@@ -96,7 +124,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
 
         [stem]
         ++++
-        K1 = "upper_index_on_u_control_points"
+        ii(K1) = bb("upper_index_on_u_control_points")
         ++++
 
       XML
@@ -118,7 +146,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
 
         [stem]
         ++++
-        s(u,v) = (1 - u -v)^{3}P_{1} + u^{3}P_{2} + v^{3}P_{3} + 3(1 - u -v)^{2}uP_{4} + 3(1 - u -v)u^{2}P_{5} + 3u^{2}vP_{6} + 3uv^{2}P_{7} + 3(1 - u -v)v^{2}P_{8} + 3(1 - u -v)^{2}vP_{9} + 6uv(1 - u -v)P_{10}
+        bb(s)(u,v) = (1 - u -v)^{3}bb(P_{1}) + u^{3}bb(P_{2}) + v^{3}bb(P_{3}) + 3(1 - u -v)^{2}ubb(P_{4}) + 3(1 - u -v)u^{2}bb(P_{5}) + 3u^{2}vbb(P_{6}) + 3uv^{2}bb(P_{7}) + 3(1 - u -v)v^{2}bb(P_{8}) + 3(1 - u -v)^{2}vbb(P_{9}) + 6uv(1 - u -v)bb(P_{10})
         ++++
 
       XML

--- a/spec/stepmod/converters/strong_spec.rb
+++ b/spec/stepmod/converters/strong_spec.rb
@@ -15,17 +15,13 @@ RSpec.describe Stepmod::Utils::Converters::Strong do
         <<~XML
           <b>
             <eqn id="eqnGM1">
-              <i>
-                &#x3C7;
-                <b><i>My node</i></b>
-                <sub>ms</sub>
-                <i>Italic text</i>
-                =
-                <b><i>V - E + 2F - L</i></b>
-                <sub>l</sub>
-                <b> - 2(S - G</b>
-                <sup>s</sup>)
-              </i>
+              &#x3C7;
+              <b>My node</b>
+              <sub>ms</sub> =
+              <b>V - E + 2F - L</b>
+              <sub>l</sub>
+              <b> - 2(S - G</b>
+              <sup>s</sup>)
               = 0 &#x2003; (1) &#x2003;
             </eqn>
           </b>
@@ -38,7 +34,7 @@ RSpec.describe Stepmod::Utils::Converters::Strong do
 
           [stem]
           ++++
-          χ My node_{ms}Italic text = V - E + 2F - L_{l} - 2(S - G^{s})  = 0
+          χ bb(My node)_{ms} = bb(V - E + 2F - L)_{l}bb(- 2(S - G)^{s}) = 0
           ++++
 
         XML
@@ -54,17 +50,14 @@ RSpec.describe Stepmod::Utils::Converters::Strong do
         <<~XML
           <b>
             <eqn>
-              <i>
-                &#x3C7;
-                <b><i>My node</i></b>
-                <sub>ms</sub>
-                <i>Italic text</i>
-                =
-                <b><i>V - E + 2F - L</i></b>
-                <sub>l</sub>
-                <b> - 2(S - G</b>
-                <sup>s</sup>)
-              </i>
+              &#x3C7;
+              <b>My node</b>
+              <sub>ms</sub>
+              =
+              <b>V - E + 2F - L</b>
+              <sub>l</sub>
+              <b> - 2(S - G</b>
+              <sup>s</sup>)
               = 0 &#x2003; (1) &#x2003;
             </eqn>
           </b>
@@ -76,7 +69,7 @@ RSpec.describe Stepmod::Utils::Converters::Strong do
 
           [stem]
           ++++
-          χ My node_{ms}Italic text = V - E + 2F - L_{l} - 2(S - G^{s})  = 0
+          χ bb(My node)_{ms} = bb(V - E + 2F - L)_{l}bb(- 2(S - G)^{s}) = 0
           ++++
 
         XML

--- a/spec/stepmod/smrl_resource_converter_spec.rb
+++ b/spec/stepmod/smrl_resource_converter_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Stepmod::Utils::SmrlResourceConverter do
 
         [stem]
         ++++
-        χ_{ms} = V - E + 2F - L_{l} - 2(S - G^{s}) = 0
+        ii(χ_{ms} = bb(V - E + 2F - L)_{l}bb(- 2(S - G)^{s})) = 0
         ++++
 
         is different from the type of the corresponding assembly constraint in the compared assembly data set.


### PR DESCRIPTION
We need to use bb() and ii() for bold and italics respectively in equations.

closes #188 
closes metanorma/stepmod2mn#93