### PR TITLE
fixing issue with eqations inside italics

### DIFF
--- a/lib/stepmod/utils/converters/em_express_description.rb
+++ b/lib/stepmod/utils/converters/em_express_description.rb
@@ -5,14 +5,41 @@ module Stepmod
     module Converters
       class Em < ReverseAdoc::Converters::Base
         def convert(node, state = {})
-          content = treat_children(node, state.merge(already_italic: true))
-          if state[:equation]
+          italic_converted(node, state)
+        end
+
+        private
+
+        def italic_converted(node, state)
+          cloned_node = node.clone
+          equations = extract_equations(cloned_node)
+          content = treat_children(cloned_node, state.merge(already_italic: true))
+          equation_content = equations.map do |equation|
+            treat(equation, state.merge(equation: true, already_italic: true))
+          end
+
+          content = if state[:equation] && !content.strip.empty?
             "ii(#{content.strip})"
           elsif content.strip.empty? || state[:already_italic]
             content
           else
             "#{content[/^\s*/]}_#{content.strip}_#{content[/\s*$/]}"
           end
+
+          [content, equation_content].compact.join("")
+        end
+
+        def extract_equations(node)
+          equations = []
+
+          node.children.each do |n|
+            next if n.name != "eqn"
+
+            equations << n
+            n.unlink
+          end
+
+          equations
         end
       end
 

--- a/spec/stepmod/converters/em_express_description_spec.rb
+++ b/spec/stepmod/converters/em_express_description_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "support/smrl_converters_setup"
+require "stepmod/utils/converters/eqn"
+
+RSpec.describe Stepmod::Utils::Converters::Em do
+  subject(:convert) do
+    cleaned_adoc(described_class.new.convert(node_for(input_xml)))
+  end
+
+  context "when there is an equation inside strong tag" do
+    context "with id" do
+      let(:input_xml) do
+        <<~XML
+          <i>
+            <eqn id="eqnGM1">
+              &#x3C7;
+              <b>My node</b>
+              <sub>ms</sub> =
+              <b>V - E + 2F - L</b>
+              <sub>l</sub>
+              <b> - 2(S - G</b>
+              <sup>s</sup>)
+              = 0 &#x2003; (1) &#x2003;
+            </eqn>
+          </i>
+        XML
+      end
+
+      let(:output) do
+        <<~XML
+          [[eqnGM1]]
+
+          [stem]
+          ++++
+          χ bb(My node)_{ms} = bb(V - E + 2F - L)_{l}bb(- 2(S - G)^{s}) = 0
+          ++++
+
+        XML
+      end
+
+      it "does not add underscores around the eqation block" do
+        expect(convert).to eq(output)
+      end
+    end
+
+    context "without id" do
+      let(:input_xml) do
+        <<~XML
+          <i>
+            <eqn>
+              &#x3C7;
+              <b>My node</b>
+              <sub>ms</sub>
+              =
+              <b>V - E + 2F - L</b>
+              <sub>l</sub>
+              <b> - 2(S - G</b>
+              <sup>s</sup>)
+              = 0 &#x2003; (1) &#x2003;
+            </eqn>
+          </i>
+        XML
+      end
+
+      let(:output) do
+        <<~XML
+
+          [stem]
+          ++++
+          χ bb(My node)_{ms} = bb(V - E + 2F - L)_{l}bb(- 2(S - G)^{s}) = 0
+          ++++
+
+        XML
+      end
+
+      it "does not add underscores around the eqation block" do
+        expect(convert).to eq(output)
+      end
+    end
+  end
+
+  context "when there is no equation inside strong tag" do
+    context "" do
+      let(:input_xml) do
+        <<~XML
+          <i>Some text that needs to be bold</i>
+        XML
+      end
+
+      let(:output) do
+        <<~OUTPUT.strip
+          _Some text that needs to be bold_
+        OUTPUT
+      end
+
+      it "add asterisks around the eqation block" do
+        expect(convert).to eq(output)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixing issue with italics around equations.

Current output
```
_[stem]
++++
|((((S^{c})[F]){ L_{l}^{e}}){E\}){V\}| + |(((S^{c})[F]){ L_{l}^{v}}){V}| - |(((S^{c})[F]){L_{l}}){E}|
++++_
```

After fix

```
[stem]
++++
|((((S^{c})[F]){ L_{l}^{e}}){E\}){V\}| + |(((S^{c})[F]){ L_{l}^{v}}){V}| - |(((S^{c})[F]){L_{l}}){E}|
++++
```