### PR TITLE
Reverting adding bb and ii in equations

### DIFF
--- a/lib/stepmod/utils/converters/em_express_description.rb
+++ b/lib/stepmod/utils/converters/em_express_description.rb
@@ -18,9 +18,7 @@ module Stepmod
             treat(equation, state.merge(equation: true, already_italic: true))
           end
 
-          content = if state[:equation] && !content.strip.empty?
-            "ii(#{content.strip})"
-          elsif content.strip.empty? || state[:already_italic]
+          content = if content.strip.empty? || state[:already_italic] || state[:equation]
             content
           else
             "#{content[/^\s*/]}_#{content.strip}_#{content[/\s*$/]}"

--- a/lib/stepmod/utils/converters/eqn.rb
+++ b/lib/stepmod/utils/converters/eqn.rb
@@ -50,8 +50,7 @@ module Stepmod
         end
 
         def stem_converted(cloned_node, state)
-          # We are now adding bb() or ii() for bold and italic respectively
-          # remove_tags_not_in_context(cloned_node)
+          remove_tags_not_in_context(cloned_node)
           internal_content = treat_children(cloned_node, state.merge(equation: true))
           content = Stepmod::Utils::HtmlToAsciimath.new.call(internal_content)
           res = <<~TEMPLATE

--- a/lib/stepmod/utils/converters/strong.rb
+++ b/lib/stepmod/utils/converters/strong.rb
@@ -20,9 +20,7 @@ module Stepmod
             treat(equation, state.merge(equation: true, already_strong: true))
           end
 
-          content = if state[:equation]
-            "bb(#{content.strip})"
-          elsif content.strip.empty? || state[:already_strong]
+          content = if content.strip.empty? || state[:already_strong] || state[:equation]
             content
           else
             strong_tag = state[:non_flanking_whitesapce] ? '**' : '*'

--- a/spec/stepmod/converters/em_express_description_spec.rb
+++ b/spec/stepmod/converters/em_express_description_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Stepmod::Utils::Converters::Em do
 
           [stem]
           ++++
-          χ bb(My node)_{ms} = bb(V - E + 2F - L)_{l}bb(- 2(S - G)^{s}) = 0
+          χ My node_{ms} = V - E + 2F - L_{l} - 2(S - G^{s}) = 0
           ++++
 
         XML
@@ -69,7 +69,7 @@ RSpec.describe Stepmod::Utils::Converters::Em do
 
           [stem]
           ++++
-          χ bb(My node)_{ms} = bb(V - E + 2F - L)_{l}bb(- 2(S - G)^{s}) = 0
+          χ My node_{ms} = V - E + 2F - L_{l} - 2(S - G^{s}) = 0
           ++++
 
         XML

--- a/spec/stepmod/converters/eqn_spec.rb
+++ b/spec/stepmod/converters/eqn_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
 
       [stem]
       ++++
-      ii(χ bb(My node)_{ms}ii(Italic text) = bb(ii(V - E + 2F - L))_{l}bb(- 2(S - G)^{s})) = 0
+      χ My node_{ms}Italic text = V - E + 2F - L_{l} - 2(S - G^{s})  = 0
       ++++
 
     XML
@@ -60,13 +60,13 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
 
         [stem]
         ++++
-        bb(λ)ii((u)) = bb(C) + R(cos(ii(u))bb(x) + sin(ii(u))bb(y))
+        λ(u) = C + R(cos(u)x + sin(u)y)
         ++++
 
       OUTPUT
     end
 
-    it "should add bb() and ii() for bold and italics respectively" do
+    it "should remove all bold and italics tags from equation" do
       expect(convert).to eq(expected_output)
     end
   end
@@ -83,7 +83,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
 
         [stem]
         ++++
-        ii(χ_{ms} = bb(V - E + 2F - L)_{l} bb(- 2(S - G) ^{s})) = 0
+        χ_{ms} = V - E + 2F - L_{l}  - 2(S - G ^{s})  = 0
         ++++
 
       XML
@@ -124,7 +124,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
 
         [stem]
         ++++
-        ii(K1) = bb("upper_index_on_u_control_points")
+        K1  = "upper_index_on_u_control_points"
         ++++
 
       XML
@@ -146,7 +146,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
 
         [stem]
         ++++
-        bb(s)(u,v) = (1 - u -v)^{3}bb(P_{1}) + u^{3}bb(P_{2}) + v^{3}bb(P_{3}) + 3(1 - u -v)^{2}ubb(P_{4}) + 3(1 - u -v)u^{2}bb(P_{5}) + 3u^{2}vbb(P_{6}) + 3uv^{2}bb(P_{7}) + 3(1 - u -v)v^{2}bb(P_{8}) + 3(1 - u -v)^{2}vbb(P_{9}) + 6uv(1 - u -v)bb(P_{10})
+        s(u,v) = (1 - u -v)^{3}P_{1} + u^{3}P_{2} + v^{3}P_{3} + 3(1 - u -v)^{2}uP_{4} + 3(1 - u -v)u^{2}P_{5} + 3u^{2}vP_{6} + 3uv^{2}P_{7} + 3(1 - u -v)v^{2}P_{8} + 3(1 - u -v)^{2}vP_{9} + 6uv(1 - u -v)P_{10}
         ++++
 
       XML

--- a/spec/stepmod/converters/strong_spec.rb
+++ b/spec/stepmod/converters/strong_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Stepmod::Utils::Converters::Strong do
 
           [stem]
           ++++
-          χ bb(My node)_{ms} = bb(V - E + 2F - L)_{l}bb(- 2(S - G)^{s}) = 0
+          χ My node_{ms} = V - E + 2F - L_{l} - 2(S - G^{s}) = 0
           ++++
 
         XML
@@ -69,7 +69,7 @@ RSpec.describe Stepmod::Utils::Converters::Strong do
 
           [stem]
           ++++
-          χ bb(My node)_{ms} = bb(V - E + 2F - L)_{l}bb(- 2(S - G)^{s}) = 0
+          χ My node_{ms} = V - E + 2F - L_{l} - 2(S - G^{s}) = 0
           ++++
 
         XML

--- a/spec/stepmod/smrl_resource_converter_spec.rb
+++ b/spec/stepmod/smrl_resource_converter_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Stepmod::Utils::SmrlResourceConverter do
 
         [stem]
         ++++
-        ii(χ_{ms} = bb(V - E + 2F - L)_{l}bb(- 2(S - G)^{s})) = 0
+        χ_{ms} = V - E + 2F - L_{l} - 2(S - G^{s}) = 0
         ++++
 
         is different from the type of the corresponding assembly constraint in the compared assembly data set.


### PR DESCRIPTION
Reverting changes to add `bb` and `ii` for bold and italics respectively in the equation. As mentioned here -> https://github.com/metanorma/stepmod-utils/issues/191#issuecomment-1815682294

For reference, the changes were done in the following PRs (Not everything is reverted only the change related to adding `bb` and `ii`)
- https://github.com/metanorma/stepmod-utils/pull/189
- https://github.com/metanorma/stepmod-utils/pull/190
