### PR TITLE
added newlines around equation, note and example blocks

### DIFF
--- a/.github/workflows/test-concept-generation.yml
+++ b/.github/workflows/test-concept-generation.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           bundle exec stepmod-annotate-all \
             --stepmod-dir ./iso-10303-stepmod-wg12 \
-            --output schemas
+            --schemas schemas
 
       - name: Generate Concept YAML files
         working-directory: iso-10303-stepmod-wg12

--- a/.github/workflows/test-concept-generation.yml
+++ b/.github/workflows/test-concept-generation.yml
@@ -26,6 +26,12 @@ jobs:
           token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
           path: iso-10303-stepmod-wg12
 
+      - name: Generate Folders for schemas
+        run: mkdir schemas
+
+      - name: Generate Folders for documents
+        run: mkdir documents
+
       - name: Generate Annotated EXPRESS files
         run: |
           bundle exec stepmod-annotate-all \

--- a/.github/workflows/test-concept-generation.yml
+++ b/.github/workflows/test-concept-generation.yml
@@ -30,7 +30,8 @@ jobs:
         run: |
           bundle exec stepmod-annotate-all \
             --stepmod-dir ./iso-10303-stepmod-wg12 \
-            --schemas schemas
+            --schemas schemas \
+            --documents documents
 
       - name: Generate Concept YAML files
         working-directory: iso-10303-stepmod-wg12

--- a/lib/stepmod/utils/converters/eqn.rb
+++ b/lib/stepmod/utils/converters/eqn.rb
@@ -60,6 +60,7 @@ module Stepmod
             #{remove_trash_symbols(content.strip)}
             ++++
 
+
           TEMPLATE
           res = "[[#{cloned_node['id']}]]\n#{res}" if cloned_node["id"]&.length&.positive?
           res

--- a/lib/stepmod/utils/converters/example.rb
+++ b/lib/stepmod/utils/converters/example.rb
@@ -10,6 +10,7 @@ module Stepmod
 
           <<~TEMPLATE
 
+
             [example]
             ====
             #{treat_children(node, state).strip}

--- a/lib/stepmod/utils/converters/express_note.rb
+++ b/lib/stepmod/utils/converters/express_note.rb
@@ -6,6 +6,7 @@ module Stepmod
       class ExpressNote < ReverseAdoc::Converters::Base
         def convert(node, state = {})
           <<~TEMPLATE
+
             (*"#{state[:schema_and_entity]}.__note"
             #{treat_children(node, state).strip}
             *)

--- a/lib/stepmod/utils/converters/figure.rb
+++ b/lib/stepmod/utils/converters/figure.rb
@@ -6,7 +6,6 @@ module Stepmod
   module Utils
     module Converters
       class Figure < ReverseAdoc::Converters::Figure
-
         def self.pattern(state, id)
           if state[:schema_and_entity].nil?
             raise StandardError.new("[figure]: no state given, #{id}")

--- a/lib/stepmod/utils/converters/note.rb
+++ b/lib/stepmod/utils/converters/note.rb
@@ -10,6 +10,7 @@ module Stepmod
 
           <<~TEMPLATE
 
+
             [NOTE]
             --
             #{treat_children(node, state).strip}

--- a/spec/fixtures/stepmod_terms_mock_directory/data/resources/presentation_appearance_schema/presentation_appearance_schema_annotated.exp
+++ b/spec/fixtures/stepmod_terms_mock_directory/data/resources/presentation_appearance_schema/presentation_appearance_schema_annotated.exp
@@ -1789,6 +1789,7 @@ The **squared_or_rounded** type specifies the appearance of curves at their corn
 image::squared_or_rounded.gif[]
 ====
 *)
+
 (*"presentation_appearance_schema.squared_or_rounded.__note"
 See figure 20.
 *)
@@ -1902,12 +1903,15 @@ The v direction count shall be greater than 1.
 The **shading_surface_method** specifies the method which shall be used for the shading of surfaces.
 *)
 
+
 (*"presentation_appearance_schema.shading_surface_method.__note"
 The descriptions of the different types of surface shading show that in some cases the method involves interpolating results from the lighting, and in other case it involves performing the reflectance calculation after interpolation. For this reason, the shading method may be thought of as selecting a location in a display system's graphics pipeline where interpolation takes place.
 *)
+
 (*"presentation_appearance_schema.shading_surface_method.__note"
 The results of the shading methods should produce the effects according to the enumerated item definitions. One particular case where the effects are difficult to define is when the silhouette of a surface intersects itself or another silhouette of the same surface. In this case, the effect is implementation-dependent.
 *)
+
 (*"presentation_appearance_schema.shading_surface_method.__note"
 The shading methods correspond to those provided by PHIGS PLUS [10].
 *)
@@ -1918,12 +1922,15 @@ the surface normals are interpolated linearly across the surface. The reflectanc
 If the <<express:presentation_appearance_schema.surface_style_rendering.surface_colour,surface_colour>> is specified through a <<express:presentation_resource_schema.colour_specification,colour_specification>>, the interpolation of colours shall be performed in the colour model of that specification. Otherwise the interpolation may be performed in an arbitrary model.
 *)
 
+
 (*"presentation_appearance_schema.shading_surface_method.normal_shading.__note"
 The result of colour interpolation depends on the colour model in which interpolation is performed.
 *)
+
 (*"presentation_appearance_schema.shading_surface_method.normal_shading.__note"
 Examples of colour models are RGB, HSV, HLS.
 *)
+
 (*"presentation_appearance_schema.shading_surface_method.normal_shading.__note"
 More information about colour models and colour interpolation can be found in [13], pp. 611-620.
 *)
@@ -1967,6 +1974,7 @@ Red Green Blue Transparency 8-bit integer storage colour model format.
 The **text_justification** type is provided to control the justification of text.
 *)
 
+
 (*"presentation_appearance_schema.text_justification.__note"
 Application Protocols shall specify legal values of the *text_justification* and shall associate precise meaning to these values.
 *)
@@ -2000,6 +2008,7 @@ Tagged Image File Format image file format.
 Bitmap image file format.
 *)
 
+
 (*"presentation_appearance_schema.texture_file_type.BMP.__note"
 This format is defined by Microsoft Windows Bitmap Format [16]
 *)
@@ -2008,6 +2017,7 @@ This format is defined by Microsoft Windows Bitmap Format [16]
 DirectDraw Surface image file format.
 *)
 
+
 (*"presentation_appearance_schema.texture_file_type.DDS.__note"
 This file format is defined by Microsoft DirectX 7 [17].
 *)
@@ -2015,6 +2025,7 @@ This file format is defined by Microsoft DirectX 7 [17].
 (*"presentation_appearance_schema.texture_file_type.TGA"
 Truevision Graphics Adapter image file format.
 *)
+
 
 (*"presentation_appearance_schema.texture_file_type.TGA.__note"
 This file format is defined by Truevision Inc. [18].
@@ -2039,6 +2050,7 @@ The **box_width** is a width scaling factor used in the definition of a characte
 A **box_slant_angle** is an angle which indicates that the box for a character glyph shall be presented as a parallelogram, with the angle being between the character up line and an axis perpendicular to the character base line.
 *)
 
+
 (*"presentation_appearance_schema.box_slant_angle.__note"
 Figure 19 shows the definition of *box_slant_angle*.
 *)
@@ -2058,6 +2070,7 @@ The **box_rotate_angle** is an angle which indicates that the box for a characte
 image::box_slant_and_rotate_angle.gif[]
 ====
 *)
+
 (*"presentation_appearance_schema.box_rotate_angle.__note"
 Figure 19 shows the definition of *box_rotate_angle*.
 *)
@@ -2087,6 +2100,7 @@ The **approximation_method** is used to enumerate two possible methods for the t
 image::chordal_deviation_and_length.gif[]
 ====
 *)
+
 (*"presentation_appearance_schema.approximation_method.__note"
 Figure 18 shows the definition of *chordal_deviation* and *chordal_length*.
 *)
@@ -2179,6 +2193,7 @@ the item to which styles are assigned.
 (*"presentation_appearance_schema.styled_item.wr:WR1"
 The set **styles** shall contain only one style or all members of the set shall be <<express:presentation_appearance_schema.presentation_style_by_context,presentation_style_by_context>> entities.
 *)
+
 
 (*"presentation_appearance_schema.styled_item.wr:WR1.__note"
 This is to ensure that there are no style conflicts; more than one style may be specified only when the context in which each style applies is given.
@@ -2297,6 +2312,7 @@ If there are two instances of <<express:presentation_appearance_schema.surface_s
 Externally defined styles shall not conflict with other styles in the same **presentation_style_assignment** entity, including other externally defined styles.
 *)
 
+
 (*"presentation_appearance_schema.presentation_style_assignment.wr:IP1.__note"
 For one style to conflict with the other, it specifies a different style for the same characteristic, such as colour or width. For example, one style might say blue, the other green, and both be applied to the same entity.
 *)
@@ -2320,6 +2336,7 @@ A **single_texture_style_tessellation_specification** is a type of <<express:pre
 the name of the external image file containing the texture to be mapped to a <<express:presentation_appearance_schema.tessellated_face_or_tessellated_surface_set,tessellated_face_or_tessellated_surface_set>> .
 *)
 
+
 (*"presentation_appearance_schema.single_texture_style_tessellation_specification.texture_image.__note"
 The name should include the format extension corresponding to one of the formats enumerated in <<express:presentation_appearance_schema.texture_file_type,texture_file_type>>.
 *)
@@ -2342,6 +2359,7 @@ when **repeating_pattern** is FALSE, U and V value range for **texture_coordinat
 (*"presentation_appearance_schema.pre_defined_presentation_style"
 A **pre_defined_presentation_style** is a type of <<express:representation_schema.founded_item,founded_item>> and a type of <<express:external_reference_schema.pre_defined_item,pre_defined_item>>. A **pre_defined_presentation_style** may be used to fix certain application-specific aspects of appearance attributes defined in this schema.
 *)
+
 
 (*"presentation_appearance_schema.pre_defined_presentation_style.__note"
 Application Resources or Application Protocols specify the use of this entity.
@@ -2386,6 +2404,7 @@ the <<express:presentation_resource_schema.colour,colour>> to be applied to the 
 A **pre_defined_marker** is a type of <<express:external_reference_schema.pre_defined_item,pre_defined_item>>. A **pre_defined_marker** may be used to define an application-specific marker symbol.
 *)
 
+
 (*"presentation_appearance_schema.pre_defined_marker.__note"
 Application Resources or Application Protocols specify the use of this entity.
 *)
@@ -2393,6 +2412,7 @@ Application Resources or Application Protocols specify the use of this entity.
 (*"presentation_appearance_schema.pre_defined_size"
 A **pre_defined_size** is a type of <<express:external_reference_schema.pre_defined_item,pre_defined_item>>. A **pre_defined_size** may be used to define an application-specific size for markers.
 *)
+
 
 (*"presentation_appearance_schema.pre_defined_size.__note"
 Application Resources or Application Protocols specify the use of this entity.
@@ -2463,6 +2483,7 @@ a <<express:measure_schema.length_measure,length_measure>> indicating how to len
 image::curve_style_with_extension.gif[]
 ====
 *)
+
 (*"presentation_appearance_schema.curve_style_with_extension.curve_extensions.__note"
 See figure 22.
 *)
@@ -2498,9 +2519,11 @@ image::illustration_of_predefined_curve_fonts.gif[]
 
 |===
 *)
+
 (*"presentation_appearance_schema.draughting_pre_defined_curve_font.__note"
 The <<express:presentation_appearance_schema.curve_style_font_and_scaling,curve_style_font_and_scaling>> is defined in ISO 10303-46.
 *)
+
 (*"presentation_appearance_schema.draughting_pre_defined_curve_font.__note"
 Illustrations of curve fonts are given in Figure 23.
 *)
@@ -2513,6 +2536,7 @@ The <<express:external_reference_schema.pre_defined_item.name,name>> of the **dr
 (*"presentation_appearance_schema.pre_defined_curve_font"
 A **pre_defined_curve_font** is a type of <<express:external_reference_schema.pre_defined_item,pre_defined_item>>. A **pre_defined_curve_font** may be used to define application-specific curve fonts.
 *)
+
 
 (*"presentation_appearance_schema.pre_defined_curve_font.__note"
 Application Resources or Application Protocols specify the use of this entity.
@@ -2603,6 +2627,7 @@ A **curve_style_curve_pattern** is a type of <<express:geometry_schema.geometric
 image::curve_style_curve_pattern.gif[]
 ====
 *)
+
 (*"presentation_appearance_schema.curve_style_curve_pattern.__note"
 Figure 21 shows the definition of *curve_style_curve_pattern*.
 *)
@@ -2676,6 +2701,7 @@ the word, or group of words, by which the **fill_area_style_colour** is referred
 A **pre_defined_hatch_style** is a type of <<express:geometry_schema.geometric_representation_item,geometric_representation_item>> and a type of <<express:external_reference_schema.pre_defined_item,pre_defined_item>>. A **pre_defined_hatch_style** is a hatching style provided for Application Protocols to define an application-specific single or multiple hatching style.
 *)
 
+
 (*"presentation_appearance_schema.pre_defined_hatch_style.__note"
 Application Resources or Application Protocols specify the use of this entity.
 *)
@@ -2695,6 +2721,7 @@ A **fill_area_style_hatching** is a type of <<express:geometry_schema.geometric_
 image::fill_area_style_hatching.gif[]
 ====
 *)
+
 (*"presentation_appearance_schema.fill_area_style_hatching.__note"
 Figure 24 shows the definition of *fill_area_style_hatching*.
 *)
@@ -2727,6 +2754,7 @@ the start point for the <<express:presentation_appearance_schema.curve_style,cur
 (*"presentation_appearance_schema.pre_defined_tile_style"
 A **pre_defined_tile_style** is a type of <<express:geometry_schema.geometric_representation_item,geometric_representation_item>> and a type of <<express:external_reference_schema.pre_defined_item,pre_defined_item>>. A **pre_defined_tile_style** is a tile style provided for Application Protocols to define an application-specific tile style.
 *)
+
 
 (*"presentation_appearance_schema.pre_defined_tile_style.__note"
 Application Resources or Application Protocols specify the use of this entity.
@@ -2801,6 +2829,7 @@ a styled annotation symbol.
 A **pre_defined_tile** is a type of <<express:external_reference_schema.pre_defined_item,pre_defined_item>>. A **pre_defined_tile** may be used to define an application-specific tile.
 *)
 
+
 (*"presentation_appearance_schema.pre_defined_tile.__note"
 Application Resources or Application Protocols specify the use of this entity.
 *)
@@ -2820,6 +2849,7 @@ A **one_direction_repeat_factor** is a type of <<express:geometry_schema.geometr
 image::one_direction_repeat_factor.gif[]
 ====
 *)
+
 (*"presentation_appearance_schema.one_direction_repeat_factor.__note"
 Figure 25 shows the positions defined by a *one_direction_repeat_factor*.
 *)
@@ -2839,6 +2869,7 @@ A **two_direction_repeat_factor** is a type of <<express:presentation_appearance
 image::two_direction_repeat_factor.gif[]
 ====
 *)
+
 (*"presentation_appearance_schema.two_direction_repeat_factor.__note"
 Figure 27 shows the positions defined by a *two_direction_repeat_factor*.
 *)
@@ -2866,6 +2897,7 @@ the style which shall be applied to the surface.
 (*"presentation_appearance_schema.pre_defined_surface_side_style"
 A **pre_defined_surface_side_style** is a type of <<express:external_reference_schema.pre_defined_item,pre_defined_item>>. A **pre_defined_surface_side_style** may be used to define an application-specific <<express:presentation_appearance_schema.surface_side_style,surface_side_style>>.
 *)
+
 
 (*"presentation_appearance_schema.pre_defined_surface_side_style.__note"
 Application Resources or Application Protocols specify the use of this entity.
@@ -2955,6 +2987,7 @@ A **surface_style_segmentation_curve** is a type of <<express:representation_sch
 the style for the segmentation curves of a surface.
 *)
 
+
 (*"presentation_appearance_schema.surface_style_segmentation_curve.style_of_segmentation_curve.__note"
 This style has only an effect on surfaces which have segmentation curves. These surfaces include the following types:
 
@@ -2972,6 +3005,7 @@ A **surface_style_control_grid** is a type of <<express:representation_schema.fo
 (*"presentation_appearance_schema.surface_style_control_grid.style_of_control_grid"
 the style for the control grid of a surface.
 *)
+
 
 (*"presentation_appearance_schema.surface_style_control_grid.style_of_control_grid.__note"
 This style has only an effect on surfaces which are defined over a mesh of control points. These surfaces include the following types:
@@ -3036,9 +3070,11 @@ All of the **properties** shall be of different types.
 A **surface_style_reflectance_ambient** is a specification of the ambient part of the reflectance behaviour of a surface.
 *)
 
+
 (*"presentation_appearance_schema.surface_style_reflectance_ambient.__note"
 The reflectance calculation is conceptually applied at one or more points on a surface being lit and shaded and produces a colour at such points. Input to the reflectance calculation includes the position at which the reflectance equation is to be applied, the surface normal, the surface colour at that position, the light sources, and the three-dimensional camera model.
 *)
+
 (*"presentation_appearance_schema.surface_style_reflectance_ambient.__note"
 Suggested reflectance equations can be found in Annex E.
 *)
@@ -3052,6 +3088,7 @@ the reflectance coefficient for the ambient part of the reflectance equation.
 A **surface_style_reflectance_ambient_diffuse** is a type of <<express:presentation_appearance_schema.surface_style_reflectance_ambient,surface_style_reflectance_ambient>>. A **surface_style_reflectance_ambient_diffuse** specifies the diffuse part of the reflectance behaviour of a surface.
 *)
 
+
 (*"presentation_appearance_schema.surface_style_reflectance_ambient_diffuse.__note"
 Suggested reflectance equations can be found in Annex E.
 *)
@@ -3064,6 +3101,7 @@ the reflectance coefficient for the diffuse part of the reflectance equation.
 (*"presentation_appearance_schema.surface_style_reflectance_ambient_diffuse_specular"
 A **surface_style_reflectance_ambient_diffuse_specular** is a type of <<express:presentation_appearance_schema.surface_style_reflectance_ambient_diffuse,surface_style_reflectance_ambient_diffuse>>. A **surface_style_reflectance_ambient_diffuse_specular** specifies the specular part of the reflectance behaviour of a surface.
 *)
+
 
 (*"presentation_appearance_schema.surface_style_reflectance_ambient_diffuse_specular.__note"
 Suggested reflectance equations can be found in Annex E.
@@ -3203,6 +3241,7 @@ A **texture_style_tessellation_specification** is a type of <<express:presentati
 A **pre_defined_character_spacing** is a type of <<express:external_reference_schema.pre_defined_item,pre_defined_item>>. A **pre_defined_character_spacing** is a character spacing for the definition of an application-specific character spacing.
 *)
 
+
 (*"presentation_appearance_schema.pre_defined_character_spacing.__note"
 Application Resources or Application Protocols specify the use of this entity.
 *)
@@ -3217,6 +3256,7 @@ A **text_style_with_mirror** is a type of <<express:presentation_appearance_sche
 image::text_style_with_mirror.gif[]
 ====
 *)
+
 (*"presentation_appearance_schema.text_style_with_mirror.__note"
 Figure 26 shows the definition of *text_style_with_mirror*.
 *)
@@ -3254,6 +3294,7 @@ A **styled_tessellated_face_or_surface_with_single_texture** is a type of <<expr
 (*"presentation_appearance_schema.styled_tessellated_face_or_surface_with_single_texture.styles"
 specifies the <<express:presentation_appearance_schema.presentation_style_assignment,presentation_style_assignment>> that specifies the texture defined by a <<express:presentation_appearance_schema.texture_style_tessellation_specification,texture_style_tessellation_specification>>.
 *)
+
 
 (*"presentation_appearance_schema.styled_tessellated_face_or_surface_with_single_texture.styles.__note"
 The actual appearance is realized in the model by the <<express:presentation_appearance_schema.presentation_style_assignment,presentation_style_assignment>> entity referenced by the *appearance* attribute.
@@ -3333,6 +3374,7 @@ An **approximation_tolerance** is a type of <<express:representation_schema.foun
 the tolerances to be used for approximating curves and surfaces.
 *)
 
+
 (*"presentation_appearance_schema.approximation_tolerance.tolerance.__note"
 If no *approximation_tolerance* is specified, the accuracy of rendering is implementation-dependent.
 *)
@@ -3384,6 +3426,7 @@ This relationship is transitive. If entity _A_ hides entity _B_, and entity _B_ 
 
 This relationship only applies if the two entities are in the same representation.
 *)
+
 
 (*"presentation_appearance_schema.occlusion_precedence.__note"
 If two such entities overlap and do not participate in an *occlusion_precedence* relationship, which entity has precedence is up to the particular implementation which presents it.

--- a/spec/stepmod/converters/em_express_description_spec.rb
+++ b/spec/stepmod/converters/em_express_description_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Stepmod::Utils::Converters::Em do
           χ My node_{ms} = V - E + 2F - L_{l} - 2(S - G^{s}) = 0
           ++++
 
+
         XML
       end
 
@@ -71,6 +72,7 @@ RSpec.describe Stepmod::Utils::Converters::Em do
           ++++
           χ My node_{ms} = V - E + 2F - L_{l} - 2(S - G^{s}) = 0
           ++++
+
 
         XML
       end

--- a/spec/stepmod/converters/eqn_spec.rb
+++ b/spec/stepmod/converters/eqn_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
       χ My node_{ms}Italic text = V - E + 2F - L_{l} - 2(S - G^{s})  = 0
       ++++
 
+
     XML
   end
 
@@ -63,6 +64,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
         λ(u) = C + R(cos(u)x + sin(u)y)
         ++++
 
+
       OUTPUT
     end
 
@@ -85,6 +87,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
         ++++
         χ_{ms} = V - E + 2F - L_{l}  - 2(S - G ^{s})  = 0
         ++++
+
 
       XML
     end
@@ -127,6 +130,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
         K1  = "upper_index_on_u_control_points"
         ++++
 
+
       XML
     end
 
@@ -148,6 +152,7 @@ RSpec.describe Stepmod::Utils::Converters::Eqn do
         ++++
         s(u,v) = (1 - u -v)^{3}P_{1} + u^{3}P_{2} + v^{3}P_{3} + 3(1 - u -v)^{2}uP_{4} + 3(1 - u -v)u^{2}P_{5} + 3u^{2}vP_{6} + 3uv^{2}P_{7} + 3(1 - u -v)v^{2}P_{8} + 3(1 - u -v)^{2}vP_{9} + 6uv(1 - u -v)P_{10}
         ++++
+
 
       XML
     end

--- a/spec/stepmod/converters/strong_spec.rb
+++ b/spec/stepmod/converters/strong_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Stepmod::Utils::Converters::Strong do
           χ My node_{ms} = V - E + 2F - L_{l} - 2(S - G^{s}) = 0
           ++++
 
+
         XML
       end
 
@@ -71,6 +72,7 @@ RSpec.describe Stepmod::Utils::Converters::Strong do
           ++++
           χ My node_{ms} = V - E + 2F - L_{l} - 2(S - G^{s}) = 0
           ++++
+
 
         XML
       end

--- a/spec/stepmod/smrl_description_converter_spec.rb
+++ b/spec/stepmod/smrl_description_converter_spec.rb
@@ -100,12 +100,14 @@ RSpec.describe Stepmod::Utils::SmrlDescriptionConverter do
         ** to check if the type of assembly constraint between components in the comparing assembly data set is different from the type of the corresponding assembly constraint in the compared assembly data set.
 
         Inspection shall be made in both ways; the comparing against the compared assembly data sets, and the compared against the comparing assembly data sets.
+
         [NOTE]
         --
         This criterion only checks the types of connecting relationship. Use the criterion <<express:Annotated_3d_model_equivalence_assembly_arm.Different_angle_of_assembly_constraint,Different_angle_of_assembly_constraint>> or <<express:Annotated_3d_model_equivalence_assembly_arm.Different_length_of_assembly_constraint,Different_length_of_assembly_constraint>> to check the difference of the dimensions specified in the constraint.
         --
 
         A <<express:analysis_schema.numerical_model,numerical_model>> is an aspect of a physical object relevant to a particular type of behavoir. A <<express:analysis_schema.numerical_model,numerical_model>> takes a particular view of its domain in terms of dimensionality and continuity.
+
         [example]
         ====
         Examples include: 3D continuum (volume elements in FEA); 2D continuum (shell elements in FEA); 1D continuum (beam elements in FEA); lumped masses (in a many-body problem).

--- a/spec/stepmod/smrl_resource_converter_spec.rb
+++ b/spec/stepmod/smrl_resource_converter_spec.rb
@@ -300,18 +300,21 @@ RSpec.describe Stepmod::Utils::SmrlResourceConverter do
         This is the first paramgraph
 
         * the definition of a given object is characterized by a set of unique properties.
+
         [example]
         ====
         A product cannot have two shapes simultaneously.
         ====
 
         * any usage of the object is characterized by a set of unique properties.
+
         [example]
         ====
         A product, like glue, may have different shapes depending on its usage.
         ====
 
         * a property characterizes either the definition or one of the usages of an object.
+
         [example]
         ====
         The appearance of chair x is a unique property of that chair. The colour designating that the chair is white is a single item in a representation for the appearance property of chair x. This colour is shareable among many representations for the properties of many different objects.

--- a/spec/stepmod/stepmod_definition_converter_spec.rb
+++ b/spec/stepmod/stepmod_definition_converter_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Stepmod::Utils::StepmodDefinitionConverter do
       <<~ADOC
         (*"aic_machining_feature.profile_floor"
         A **profile_floor** is a type of *shape_aspect* that is the representation of the bottom condition for an *outside_profile* *feature_definition*.
+
         [NOTE]
         --
         A *Profile_floor*, *General_profile_floor* or a *Planar_profile_floor* are defined in ISO 10303-1814 [5] and define the requirement for **profile_floor**.

--- a/spec/stepmod/stepmod_file_annotator_spec.rb
+++ b/spec/stepmod/stepmod_file_annotator_spec.rb
@@ -119,9 +119,11 @@ RSpec.describe Stepmod::Utils::StepmodFileAnnotator do
         (*"Activity_arm.Activity.__example"
         Change, distilling, design, a process to drill a hole, and a task such as training someone, are examples of activities.
         *)
+
         (*"Activity_arm.Activity.__note"
         Status information identifying the level of completion of each activity may be provided within an instance of <<express:Activity_arm.Activity_status,Activity_status>>.
         *)
+
         (*"Activity_arm.Activity.__note"
         The items that are affected by an *Activity*, for example as input or output, may be identified within an instance of <<express:Activity_arm.Applied_activity_assignment,Applied_activity_assignment>>.
         *)


### PR DESCRIPTION
Fixes the spacing issue around `notes`, `examples` and `equation` blocks as mentioned in https://github.com/metanorma/stepmod-utils/issues/223