### PR TITLE
updated to not create empty changes files

### DIFF
--- a/exe/stepmod-srl-migrate
+++ b/exe/stepmod-srl-migrate
@@ -4,6 +4,7 @@
 
 require "pathname"
 require "fileutils"
+require "nokogiri"
 bin_file = Pathname.new(__FILE__).realpath
 
 # add self to libpath
@@ -17,16 +18,39 @@ def log(message, indent = 0)
   puts "[stepmod-utils] #{message}"
 end
 
-def copy_files_to_schemas(path, stepmod_path, srl_output_docs_dir)
+def copy_files_to_schemas(path, stepmod_path, srl_output_schemas_dir)
   base_path = path.dirname.relative_path_from(File.join(stepmod_path, "data"))
   file_name = path.basename
 
-  new_dir = File.join(srl_output_docs_dir, base_path.to_s)
+  new_dir = File.join(srl_output_schemas_dir, base_path.to_s)
   new_file_path = File.join(new_dir, file_name)
 
   unless Dir.exist?(new_dir)
     FileUtils.mkdir_p(new_dir)
   end
+
+  FileUtils.copy_file(path, new_file_path)
+  log("Copied #{path.basename} to #{new_file_path}", 1)
+end
+
+def copy_files_to_document(path, stepmod_path, srl_output_docs_dir)
+  base_path = path.dirname.relative_path_from(File.join(stepmod_path, "data"))
+  file_name = path.basename
+  module_xml_path = path.dirname.join('module.xml')
+  # puts "module_xml_path #{module_xml_path}"
+  module_xml = Nokogiri::XML(IO.read(module_xml_path)).root
+
+  part_number = module_xml.xpath('//module').first.attr('part')
+  # module_name = module_xml.xpath('//module').first.attr('name')
+
+  new_dir = File.join(srl_output_docs_dir, "iso-10303-#{part_number}")
+  new_file_path = File.join(new_dir, file_name)
+  # new_file_path = File.join(new_dir, "#{module_name}.#{file_name}")
+
+  ## The document directory should already exist.
+  # unless Dir.exist?(new_dir)
+  #   FileUtils.mkdir_p(new_dir)
+  # end
 
   FileUtils.copy_file(path, new_file_path)
   log("Copied #{path.basename} to #{new_file_path}", 1)
@@ -171,10 +195,19 @@ log("[SRL MIGRATION: stepmod-utils] COMPLETE Annotated EXPRESS generation.")
 log("*"*30)
 log("[SRL MIGRATION: stepmod-utils] START EXPRESS change YAML extraction.")
 system "stepmod-extract-changes -p #{stepmod_dir}"
+
+# Move arm/mim/arm_lf/mim_lf/mapping changes into schema directories
 Dir.glob("#{stepmod_dir}/data/**/*.changes.yaml").each do |filepath|
   path = Pathname.new(filepath)
   copy_files_to_schemas(path, stepmod_dir, srl_output_schemas_dir)
 end
+
+# Move document changes into document directories
+Dir.glob("#{stepmod_dir}/data/**/changes.yaml").each do |filepath|
+  path = Pathname.new(filepath)
+  copy_files_to_document(path, stepmod_dir, srl_output_docs_dir)
+end
+
 log("*"*30)
 log("[SRL MIGRATION: stepmod-utils] COMPLETE EXPRESS change YAML extraction.")
 

--- a/lib/stepmod/utils/change.rb
+++ b/lib/stepmod/utils/change.rb
@@ -13,6 +13,8 @@ module Stepmod
         mim: "mim",
         arm_longform: "arm_lf",
         mim_longform: "mim_lf",
+        mapping: "mapping",
+        changes: "",
       }.freeze
 
       def initialize(stepmod_dir:, schema_name:, type:)
@@ -65,8 +67,14 @@ module Stepmod
           "data",
           base_folder,
           schema_name,
-          "#{MODULE_TYPES[type.to_sym] || schema_name}.changes.yaml",
+          filename(type),
         )
+      end
+
+      def filename(type)
+        return "changes.yaml" if type.to_s == "changes"
+
+        "#{MODULE_TYPES[type.to_sym] || schema_name}.changes.yaml"
       end
 
       def base_folder

--- a/lib/stepmod/utils/change.rb
+++ b/lib/stepmod/utils/change.rb
@@ -40,13 +40,20 @@ module Stepmod
       alias_method :[], :fetch_change_edition
 
       def save_to_file
-        File.write(filepath(@type), Psych.dump(to_h))
+        change_hash = to_h
+        return if change_hash.empty?
+
+        File.write(filepath(@type), Psych.dump(change_hash))
       end
 
       def to_h
+        change_editions_list = change_editions.to_h
+
+        return {} if change_editions_list.empty?
+
         {
           "schema" => schema_name,
-          "change_edition" => change_editions.to_h,
+          "change_edition" => change_editions_list,
         }
       end
 

--- a/lib/stepmod/utils/change_edition.rb
+++ b/lib/stepmod/utils/change_edition.rb
@@ -2,7 +2,7 @@ module Stepmod
   module Utils
     class ChangeEdition
       attr_accessor :version, :description
-      attr_reader :additions, :modifications, :deletions, :mapping
+      attr_reader :additions, :modifications, :deletions, :changes
 
       def initialize(options)
         @version = options[:version]
@@ -10,7 +10,7 @@ module Stepmod
         self.additions = options[:additions] || []
         self.modifications = options[:modifications] || []
         self.deletions = options[:deletions] || []
-        self.mapping = options[:mapping] || []
+        self.changes = options[:changes] || []
       end
 
       def additions=(additions)
@@ -31,10 +31,10 @@ module Stepmod
         @deletions = deletions
       end
 
-      def mapping=(mapping)
-        validate_type("mapping", mapping, Array)
+      def changes=(changes)
+        validate_type("changes", changes, Array)
 
-        @mapping = mapping
+        @changes = changes
       end
 
       def to_h
@@ -44,7 +44,7 @@ module Stepmod
           "additions" => additions,
           "modifications" => modifications,
           "deletions" => deletions,
-          "mapping" => mapping,
+          "changes" => changes,
         }.reject { |_k, v| v.nil? || v.empty? }
       end
 

--- a/lib/stepmod/utils/changes_extractor.rb
+++ b/lib/stepmod/utils/changes_extractor.rb
@@ -97,8 +97,10 @@ module Stepmod
         schema_name = options[:schema_name]
         change = collection.fetch_or_initialize(schema_name, type)
 
-        change_edition = extract_change_edition(changes, options)
-        change.add_change_edition(change_edition)
+        unless changes.nil? && options[:description].nil?
+          change_edition = extract_change_edition(changes, options)
+          change.add_change_edition(change_edition)
+        end
 
         if type == "arm"
           add_mapping_changes(collection, change_node, options)
@@ -106,12 +108,15 @@ module Stepmod
       end
 
       def add_mapping_changes(collection, change_node, options)
+        mapping_changes = extract_mapping_changes(change_node)
+        return if mapping_changes.empty?
+
         change_edition = collection
                          .fetch_or_initialize(options[:schema_name], "arm")
                          .change_editions
                          .fetch_or_initialize(options[:version])
 
-        change_edition.mapping = extract_mapping_changes(change_node)
+        change_edition.mapping = mapping_changes
       end
 
       def extract_mapping_changes(change_node)

--- a/spec/stepmod/changes_extractor_spec.rb
+++ b/spec/stepmod/changes_extractor_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Stepmod::Utils::ChangesExtractor do
       let(:change_collection) { subject.call }
 
       it "should create the collection from fixture files" do
-        expect(change_collection.count).to eq(31)
+        expect(change_collection.count).to eq(32)
       end
     end
 
@@ -74,25 +74,25 @@ RSpec.describe Stepmod::Utils::ChangesExtractor do
       let(:schema_name) { "test_schema" }
 
       it "should add mapping changes to version 3 change editions" do
-        change_edition = change_collection.fetch(schema_name, "arm")
+        change_edition = change_collection.fetch(schema_name, "mapping")
                                           .change_editions["3"]
+
         mapping = [
           { "change" => "ENTITY Description_text_assignment" },
           { "change" => "ENTITY Description_text" },
         ]
 
-        expect(change_edition.mapping).to eq(mapping)
+        expect(change_edition.changes).to eq(mapping)
       end
 
-      it "should add description to all version 2 changes" do
+      it "should add description to only version 2 changes.yaml" do
         description = "The scope statement has been amended in order to " \
                       "clarify the appropriate use of this module."
 
-        change_collection.each do |change|
-          change_edition = change.fetch_change_edition("2")
+        change_edition = change_collection.fetch(schema_name, "changes")
+                                          .fetch_change_edition("2")
 
-          expect(change_edition.description).to eq(description)
-        end
+        expect(change_edition.description).to eq(description)
       end
     end
 


### PR DESCRIPTION
The issue is that changes files are being generated for all the schemas even if there are no changes for that type.
I have updated the code and now it no longer generates these files if they are empty.