### PR TITLE
changes.yaml missing description

### DIFF
--- a/lib/stepmod/utils/changes_extractor.rb
+++ b/lib/stepmod/utils/changes_extractor.rb
@@ -176,7 +176,7 @@ collection)
 
         {
           version: options[:version],
-          description: options[:description],
+          description: options[:description] || converted_description(schema_changes.xpath("description").first),
           additions: extract_modified_objects(addition_nodes),
           modifications: extract_modified_objects(modification_nodes),
           deletions: extract_modified_objects(deletion_nodes),

--- a/spec/stepmod/changes_extractor_spec.rb
+++ b/spec/stepmod/changes_extractor_spec.rb
@@ -321,6 +321,38 @@ RSpec.describe Stepmod::Utils::ChangesExtractor do
         end
       end
 
+      context "arm.changes with only description" do
+        let(:xml_data) do
+          xml = <<~XML
+            <arm.changes>
+              <description>ARM EXPRESS-G Diagrams have been updated</description>
+            </arm.changes>
+          XML
+
+          Nokogiri::XML(xml).root
+        end
+
+        let(:options) do
+          {
+            type: "arm",
+          }
+        end
+
+        let(:output) do
+          {
+            version: nil,
+            description: "ARM EXPRESS-G Diagrams have been updated",
+            additions: [],
+            modifications: [],
+            deletions: [],
+          }
+        end
+
+        it "should return correct output" do
+          expect(extract_change_edition).to eq(output)
+        end
+      end
+
       context "mim.changes" do
         let(:xml_data) do
           xml = <<~XML


### PR DESCRIPTION
Fixing changes YAML missing `changes/change/arm.changes/description` element.

fixes #257 