### PR TITLE
normalize schema names

### DIFF
--- a/lib/stepmod/utils/changes_extractor.rb
+++ b/lib/stepmod/utils/changes_extractor.rb
@@ -217,6 +217,8 @@ collection)
 
       # rubocop:disable Layout/LineLength
       def correct_schema_name(schema_name)
+        schema_name = schema_name.downcase
+
         schema_name_corrector = {
           "material_property_definition" => "material_property_definition_schema",
           "qualified_measure" => "qualified_measure_schema",

--- a/spec/fixtures/stepmod_terms_mock_directory/data/resource_docs/visual_presentation/resource.xml
+++ b/spec/fixtures/stepmod_terms_mock_directory/data/resource_docs/visual_presentation/resource.xml
@@ -185,7 +185,7 @@
       </change_edition>
       <change_edition version="3">
          <description>Presentation appearance schema's Scope and Fundamental concepts and assumptions clause updated.</description>
-         <schema.changes schema_name="presentation_appearance_schema">
+         <schema.changes schema_name="PRESENTATION_APPEARANCE_SCHEMA">
             <schema.additions>
                <modified.object name="geometric_model_schema" type="REFERENCE_FROM"/>
                <modified.object name="product_property_representation_schema" type="REFERENCE_FROM"/>


### PR DESCRIPTION
Normalized schema names by downcasing so schema names in different casing don't get confused for different schemas.

fixes #269